### PR TITLE
Allow specifying light and speaker service types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "homebridge-rusty-spotify"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["anna <anna@scholtzan.net>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ $ ./generate_config --client_id=<client_id> --client_secret=<client_secret> --us
   {
     "platform": "Spotify",
     "name": "Spotify",
+    "service_type": "light",    // "light" or "speaker"; Speaker is not supported by HomeKit
     "client_id": "<client_id>",
     "client_secret": "<client_secret>",
     "refresh_token": "<refresh_token>"
@@ -60,6 +61,7 @@ The generated config needs to copied to the Homebridge config file (e.g. `~/.hom
   {
     "platform": "Spotify",
     "name": "Spotify",
+    "service_type": "light",    // "light" or "speaker"; Speaker is not supported by HomeKit
     "client_id": "<client_id>",
     "client_secret": "<client_secret>",
     "refresh_token": "<refresh_token>",
@@ -67,6 +69,10 @@ The generated config needs to copied to the Homebridge config file (e.g. `~/.hom
 ]
 //...
 ```
+
+`service_type` specifies whether Spotify devices should use the [Lightbulb](https://developers.homebridge.io/#/service/Lightbulb)
+or [Speaker](https://developers.homebridge.io/#/service/Speaker) service. If `service_type` is not specified, `"light"` will be used by default.
+HomeKit currently does not support Speaker services and will show _"This accessory is not certified and may not work reliably with HomeKit"_. 
 
 ## Usage
 

--- a/generate_config
+++ b/generate_config
@@ -56,6 +56,7 @@ def main():
     config = {
         "platform": "Spotify",
         "name": "Spotify",
+        "service_type": "light",    // "light" or "speaker"; Speaker is not supported by HomeKit
         "client_id": args.client_id,
         "client_secret": args.client_secret,
         "refresh_token": token_info["refresh_token"]

--- a/index.js
+++ b/index.js
@@ -10,11 +10,17 @@ module.exports = function(homebridge) {
   UUIDGen = homebridge.hap.uuid;
   Characteristic = homebridge.hap.Characteristic;
 
-  createSwitch = function(name) {
+  createLight = function(name) {
     let newSwitch = new Service.Lightbulb(name);
     // we'll use brightness to control the volume
     newSwitch.addCharacteristic(Characteristic.Brightness);
     return newSwitch;
+  }
+
+  createSpeaker = function(name) {
+    let newSpeaker = new Service.Speaker(name);
+    newSpeaker.addCharacteristic(Characteristic.Volume);
+    return newSpeaker;
   }
 
   constructor = partial(SpotifyPlatform, homebridge);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "collaborators": [
     "anna <anna@scholtzan.net>"
   ],
-  "version": "0.4.3",
+  "version": "0.4.4",
   "files": [
     "homebridge_rusty_spotify_bg.wasm",
     "homebridge_rusty_spotify.js",


### PR DESCRIPTION
Fixes https://github.com/scholtzan/homebridge-rusty-spotify/issues/11
